### PR TITLE
expose Typescript type correctly

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,8 +35,14 @@
     "ts"
   ],
   "exports": {
-    ".": "./js/public/index.js",
-    "./*": "./js/public/*/index.js"
+    ".": {
+      "types": "./ts/public/index.ts",
+      "import": "./js/public/index.js"
+    },
+    "./*": {
+      "types": "./ts/public/*/index.ts",
+      "import": "./js/public/*/index.js"
+    }
   },
   "typesVersions": {
     "*": {


### PR DESCRIPTION
At the moment, the type of this package is not exposed correctly, and I get the following error:

```ts
  There are types at 'golte/ts/public/config/index.ts', but this result could not be resolved when respecting package.json "exports". The 'golte' library may need to update its package.json or typings.ts(7016)
```

This PR is trying to fix this by explicitly export types.